### PR TITLE
Fix/weaponsforge 48b

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,9 @@ jobs:
           cd client
           npm install
       - name: Lint
-        run: npm run lint
+        run: |
+          cd client
+          npm run lint
       - name: Export static files
         run: |
           cd client


### PR DESCRIPTION
- Fix the client app directory path on the release gh actions yml  (Lint workflow)