### PR TITLE
Feature/weaponsforge 61

### DIFF
--- a/client/components/common/ui/loadingindicator/index.js
+++ b/client/components/common/ui/loadingindicator/index.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types'
+import CircularProgress from '@mui/material/CircularProgress'
+
+function LoadingIndicator ({
+  size = 24,
+  loadingLabel = 'Loading...'
+}) {
+  return (
+    <div style={{ width: '100%', minHeight: '300px', display: 'grid', placeContent: 'center' }}>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <span>{loadingLabel}</span>&nbsp;&nbsp;&nbsp;
+        <CircularProgress size={size} />
+      </div>
+    </div>
+  )
+}
+
+LoadingIndicator.propTypes = {
+  size: PropTypes.number,
+  loadingLabel: PropTypes.string
+}
+
+export default LoadingIndicator

--- a/client/features/authentication/components/withauth/index.js
+++ b/client/features/authentication/components/withauth/index.js
@@ -24,7 +24,7 @@ function WithAuth (Component) {
       }
     }, [authUser, authLoading, router])
 
-    const ItemComponent = () => {
+    return ((() => {
       if (authLoading) {
         return <LoadingCover />
       } else if (authUser) {
@@ -32,9 +32,7 @@ function WithAuth (Component) {
       } else {
         return <LoadingCover authError={authError} />
       }
-    }
-
-    return (<ItemComponent />)
+    })())
   }
 
   return AuthListener

--- a/client/features/authentication/components/withcmsauth/index.js
+++ b/client/features/authentication/components/withcmsauth/index.js
@@ -30,7 +30,7 @@ function WithCMSAuth (Component) {
       }
     }, [authUser, authLoading, router])
 
-    const ItemComponent = () => {
+    return ((() => {
       if (authLoading) {
         return <LoadingCover />
       } else if (authUser) {
@@ -42,9 +42,7 @@ function WithCMSAuth (Component) {
       } else {
         return <LoadingCover authError={authError} />
       }
-    }
-
-    return (<ItemComponent />)
+    })())
   }
 
   return AuthListener

--- a/client/features/posts/components/layout/metadataform/items.json
+++ b/client/features/posts/components/layout/metadataform/items.json
@@ -1,5 +1,6 @@
 [
   { "id": "title", "label": "Title", "placeholder": "Enter the document title" },
+  { "id": "description", "label": "Description", "placeholder": "Enter the Post's description" },
   { "id": "slug", "label": "Slug", "placeholder": "Enter the Post slug" },
   { "id": "country", "label": "Country", "placeholder": "Enter the Post's country" },
   { "id": "author", "label": "Author", "placeholder": "Enter the author name" }

--- a/client/features/posts/components/list/index.js
+++ b/client/features/posts/components/list/index.js
@@ -1,7 +1,32 @@
+import { useSelector } from 'react-redux'
+import PropTypes from 'prop-types'
+
+import {
+  DataGrid,
+  GridToolbarColumnsButton,
+  GridToolbarFilterButton,
+  GridToolbarContainer
+} from '@mui/x-data-grid'
+
 import { SectionComponent } from '@/features/cms'
 import HeaderNav from '../layout/headernav'
+import { ADAPTER_STATES } from '@/store/constants'
 
-function PostsComponent () {
+function CustomToolbar(props) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+      <GridToolbarContainer {...props}>
+        <GridToolbarColumnsButton />
+        <GridToolbarFilterButton />
+      </GridToolbarContainer>
+    </div>
+  )
+}
+
+function PostsComponent ({ columns }) {
+  const posts = useSelector(state => state.posts.entities)
+  const status = useSelector(state => state.posts.status)
+
   return (
     <>
       <SectionComponent>
@@ -11,9 +36,33 @@ function PostsComponent () {
           buttonLink='/cms/posts/create'
           buttonLabel='Create Post'
         />
+
+        <div style={{ height: 640, width: '100%', textAlign: 'left' }}>
+          <DataGrid
+            columns={columns}
+            rows={Object.values(posts)}
+            loading={status === ADAPTER_STATES.PENDING}
+            components={{ Toolbar: CustomToolbar }}
+            maxColumns={4}
+            initialState={{
+              pagination: {
+                paginationModel: { pageSize: 10 }
+              }
+            }}
+            pageSizeOptions={[10, 20, 50]}
+            /* eslint-disable no-unused-vars */
+            onRowClick={(row) => {
+              // console.log(row)
+            }}
+          />
+        </div>
       </SectionComponent>
     </>
   )
+}
+
+PostsComponent.propTypes = {
+  columns: PropTypes.array
 }
 
 export default PostsComponent

--- a/client/features/posts/components/list/index.js
+++ b/client/features/posts/components/list/index.js
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux'
+import { useRouter } from 'next/router'
 import PropTypes from 'prop-types'
 
 import {
@@ -26,6 +27,7 @@ function CustomToolbar(props) {
 function PostsComponent ({ columns }) {
   const posts = useSelector(state => state.posts.entities)
   const status = useSelector(state => state.posts.status)
+  const router = useRouter()
 
   return (
     <>
@@ -50,9 +52,9 @@ function PostsComponent ({ columns }) {
               }
             }}
             pageSizeOptions={[10, 20, 50]}
-            /* eslint-disable no-unused-vars */
             onRowClick={(row) => {
               // console.log(row)
+              router.push(`/cms/posts/view?id=${row.id}`)
             }}
           />
         </div>

--- a/client/features/posts/components/viewpost/index.js
+++ b/client/features/posts/components/viewpost/index.js
@@ -1,17 +1,58 @@
+import { useSelector } from 'react-redux'
+import { ADAPTER_STATES } from '@/store/constants'
+
 import Typography from '@mui/material/Typography'
+
 import { SectionComponent } from '@/features/cms'
+import LoadingIndicator from '@/components/common/ui/loadingindicator'
+import HeaderNav from '../layout/headernav'
+
+const orderedKeys = [
+  'id',
+  'title',
+  'description',
+  'slug',
+  'country',
+  'author',
+  'date_created',
+  'date_updated'
+]
 
 function ViewPostComponent () {
+  const post = useSelector(state => state.posts.post)
+  const status = useSelector(state => state.posts.status)
+
   return (
     <>
       <SectionComponent>
-        <Typography variant='h4'>
-          Post
-        </Typography>
+        {/** Header */}
+        <HeaderNav
+          title='Post'
+          subTitle='View Post content.'
+          buttonLink='/cms/posts'
+          buttonLabel='Cancel'
+          disabled={status === ADAPTER_STATES.PENDING}
+        />
 
-        <Typography variant='body'>
-          View Post content.
-        </Typography>
+        {(status === ADAPTER_STATES.IDLE && post !== null) &&
+        <div>
+          {orderedKeys.map((key, index) => (
+            <div key={index}>
+              <Typography variant='label'><b>{key}:</b> </Typography>
+              <Typography variant='label'>{post[key]}</Typography>
+            </div>
+          ))}
+        </div>
+        }
+      </SectionComponent>
+
+      <SectionComponent>
+        {(status === ADAPTER_STATES.PENDING)
+          ? <LoadingIndicator />
+          : (post !== null)
+            ? <div dangerouslySetInnerHTML={{ __html: post.content }} />
+            : <div>Error retrieving Post. Please check the Post ID and try again.</div>
+        }
       </SectionComponent>
     </>
   )

--- a/client/features/posts/containers/createpost/index.js
+++ b/client/features/posts/containers/createpost/index.js
@@ -7,7 +7,7 @@ import { useAuth } from '@/features/authentication'
 
 import CreatePostComponent from '../../components/createpost'
 
-const defaultState = { title: '', slug: '', country: '', author: '' }
+const defaultState = { title: '', description: '', slug: '', country: '', author: '' }
 const defaultSaveStatus = { isOpenDialog: false, saveSuccess: false }
 
 function CreatePost () {

--- a/client/features/posts/containers/list/index.js
+++ b/client/features/posts/containers/list/index.js
@@ -1,21 +1,14 @@
-import { useEffect, useState } from 'react'
 import PostsComponent from '../../components/list'
 
 function PostsList () {
-  const [columns, setColumns] = useState([])
-
-  useEffect(() => {
-    setColumns([
-      { field: 'title', headerName: 'Title', minWidth: 250, flex: 1 },
-      { field: 'country', headerName: 'Country', minWidth: 220 },
-      { field: 'slug', headerName: 'Slug', minWidth: 250 },
-      { field: 'date_created', headerName: 'Date Created', minWidth: 250 }
-    ])
-  }, [])
-
   return (
     <PostsComponent
-      columns={columns}
+      columns={[
+        { field: 'title', headerName: 'Title', minWidth: 250, flex: 1 },
+        { field: 'country', headerName: 'Country', minWidth: 220 },
+        { field: 'slug', headerName: 'Slug', minWidth: 250 },
+        { field: 'date_created', headerName: 'Date Created', minWidth: 250 }
+      ]}
     />
   )
 }

--- a/client/features/posts/containers/list/index.js
+++ b/client/features/posts/containers/list/index.js
@@ -1,8 +1,22 @@
+import { useEffect, useState } from 'react'
 import PostsComponent from '../../components/list'
 
 function PostsList () {
+  const [columns, setColumns] = useState([])
+
+  useEffect(() => {
+    setColumns([
+      { field: 'title', headerName: 'Title', minWidth: 250, flex: 1 },
+      { field: 'country', headerName: 'Country', minWidth: 220 },
+      { field: 'slug', headerName: 'Slug', minWidth: 250 },
+      { field: 'date_created', headerName: 'Date Created', minWidth: 250 }
+    ])
+  }, [])
+
   return (
-    <PostsComponent />
+    <PostsComponent
+      columns={columns}
+    />
   )
 }
 

--- a/client/features/posts/containers/viewpost/index.js
+++ b/client/features/posts/containers/viewpost/index.js
@@ -1,6 +1,38 @@
+import { useEffect, useRef } from 'react'
+import { useRouter } from 'next/router'
+import { useDispatch } from 'react-redux'
+
+import { _getPost } from '@/store/posts/postThunks'
+import { MESSAGE_SEVERITY, notificationReceived } from '@/store/app/appSlice'
+import { useAuth } from '@/features/authentication'
+
 import ViewPostComponent from '../../components/viewpost'
 
 function ViewPost () {
+  const { authUser } = useAuth()
+  const router = useRouter()
+  const mounted = useRef()
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    if (
+      router.isReady &&
+      mounted.current === undefined &&
+      authUser !== null
+    ) {
+      dispatch(_getPost(`users/${authUser.uid}/posts/${router.query.id}`))
+        .unwrap()
+        .then()
+        .catch((error) => {
+          dispatch(notificationReceived({
+            notification: error ?? 'Error loading the post',
+            severity: MESSAGE_SEVERITY.ERROR
+          }))
+        })
+      mounted.current = true
+    }
+  }, [dispatch, router.isReady, router.query, authUser])
+
   return (
     <ViewPostComponent />
   )

--- a/client/features/posts/hooks/useinitposts.js
+++ b/client/features/posts/hooks/useinitposts.js
@@ -4,7 +4,8 @@ import { _getPosts } from '@/store/posts/postThunks'
 import { loadedReceived } from '@/store/app/appSlice'
 
 /**
- * Fetch all user's Posts only once during the initial app load (of any <WithCMSAuth> wrapped components)
+ * Fetch all user's (reference) Posts only once during the initial app load (of any <WithCMSAuth> wrapped components).
+ * The reference Posts documents contain the original Posts data minus the Post.content field.
  * @param {String} uid - Signed-in Firebase user's auth ID
  * @returns {Bool} - Client app's initial load state
  */
@@ -14,7 +15,7 @@ export default function useInitPosts (uid) {
 
   useEffect(() => {
     if (!loaded && uid !== undefined) {
-      dispatch(_getPosts(`users/${uid}/posts`))
+      dispatch(_getPosts(`users/${uid}/posts_ref`))
       dispatch(loadedReceived(true))
     }
   }, [dispatch, uid, loaded])

--- a/client/src/lib/store/posts/postSlice.js
+++ b/client/src/lib/store/posts/postSlice.js
@@ -5,7 +5,8 @@ import {
 
 import {
   _createPost,
-  _getPosts
+  _getPosts,
+  _getPost
 } from '@/store/posts/postThunks'
 
 import { ADAPTER_STATES } from '@/store/constants'
@@ -50,11 +51,32 @@ const postSlice = createSlice({
     builder.addCase(_getPosts.fulfilled, (state, { payload }) => {
       state.status = ADAPTER_STATES.IDLE
       state.currentRequestId = undefined
-      state.post = null
+      // state.post = null
       postsAdapter.setAll(state, payload)
     })
 
     builder.addCase(_getPosts.rejected, (state, action) => {
+      const { message } = action.error
+      state.status = ADAPTER_STATES.IDLE
+      state.error = action?.payload ?? message
+      state.currentRequestId = undefined
+      state.post = null
+    })
+
+    // Fetch Post thunk handler
+    builder.addCase(_getPost.fulfilled, (state, action) => {
+      state.status = ADAPTER_STATES.IDLE
+      state.currentRequestId = undefined
+      state.post = action.payload
+
+      // Remove the content field
+      const post = { ...action.payload, content: '-' }
+
+      // Insert the new Post to the collection of Posts
+      postsAdapter.addOne(state, post)
+    })
+
+    builder.addCase(_getPost.rejected, (state, action) => {
       const { message } = action.error
       state.status = ADAPTER_STATES.IDLE
       state.error = action?.payload ?? message

--- a/client/src/lib/store/posts/postSlice.js
+++ b/client/src/lib/store/posts/postSlice.js
@@ -72,8 +72,12 @@ const postSlice = createSlice({
         state.status = ADAPTER_STATES.IDLE
         state.currentRequestId = undefined
         state.post = action.payload
+
+        // Remove the content field
+        const post = { ...action.payload, content: '-' }
+
         // Insert the new Post to the collection of Posts
-        postsAdapter.addOne(state, action.payload)
+        postsAdapter.addOne(state, post)
       }
     })
 

--- a/client/src/lib/store/posts/postSlice.js
+++ b/client/src/lib/store/posts/postSlice.js
@@ -13,7 +13,8 @@ import { ADAPTER_STATES } from '@/store/constants'
 // Entity adapter - redux state of this slice
 // By default, `createEntityAdapter` gives you `{ ids: [], entities: {} }`.
 export const postsAdapter = createEntityAdapter({
-  selectId: (post) => post.id
+  selectId: (post) => post.id,
+  sortComparer: (a, b) => (new Date(b.date_created) - new Date(a.date_created))
 })
 
 const postSlice = createSlice({

--- a/client/src/lib/store/posts/postThunks.js
+++ b/client/src/lib/store/posts/postThunks.js
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { postsLoading } from './postSlice'
-import { createPost, getPosts } from '@/services/posts'
+import { createPost, getPosts, getPost } from '@/services/posts'
 import { ADAPTER_STATES } from '@/store/constants'
 import { timestampToDateString } from '@/utils/firestoreutils'
 
@@ -45,6 +45,28 @@ export const _getPosts = createAsyncThunk('posts/list', async (collectionPath, t
       date_created: timestampToDateString(item.date_created),
       date_updated: timestampToDateString(item.date_updated)
     }))
+  } catch (err) {
+    return thunkAPI.rejectWithValue(err?.response?.data ?? err.message)
+  }
+})
+
+/**
+ * Fetch the full, original Post thunk
+ */
+export const _getPost = createAsyncThunk('posts/view', async (documentPath, thunkAPI) => {
+  try {
+    thunkAPI.dispatch(postsLoading(thunkAPI.requestId))
+    const response = await getPost(documentPath)
+
+    if (response === undefined) {
+      return thunkAPI.rejectWithValue('Post document not found.')
+    } else {
+      return {
+        ...response,
+        date_created: timestampToDateString(response.date_created),
+        date_updated: timestampToDateString(response.date_updated)
+      }
+    }
   } catch (err) {
     return thunkAPI.rejectWithValue(err?.response?.data ?? err.message)
   }

--- a/client/src/lib/utils/firestoreutils.js
+++ b/client/src/lib/utils/firestoreutils.js
@@ -68,8 +68,12 @@ const getDocument = async (pathToDocument) => {
  */
 const createDocument = async (pathToCollection, params) => {
   const docId = generateDocumentId(pathToCollection)
-  await setDoc(doc(db, pathToCollection, docId.id), { ...params, id: docId.id })
-  return await getDocument(`${pathToCollection}/${docId.id}`)
+
+  const postId = (params.id === undefined)
+    ? docId.id
+    : params.id
+
+  await setDoc(doc(db, pathToCollection, postId), { ...params, id: postId })
 }
 
 export {


### PR DESCRIPTION
- Create a light-weight mirror Post document for reference in  `/users/{uid}/posts_ref`, containing all Post fields minus the `content` field
- Fetch all Posts and display them in a list, [#61](https://github.com/weaponsforge/climate-profile-full/issues/61) 
   - This list ldisplays Documents from the the Firestore `/users/{uid}/posts_ref` collection
- Fetch and view a Post document, [#62](https://github.com/weaponsforge/climate-profile-full/issues/62)
