### PR TITLE
Update/weaponsforge 85d

### DIFF
--- a/client/features/filecards/components/cardpreview/index.js
+++ b/client/features/filecards/components/cardpreview/index.js
@@ -26,7 +26,7 @@ function CardPreview () {
     if (card !== null) {
       subtitle = <span>{card?.subtitle ?? ''}</span>
 
-      if (card?.website_url !== '') {
+      if (card?.website_url.includes('http')) {
         subtitle = <Link href={card.website_url} target="_blank">
           {subtitle}
         </Link>

--- a/client/features/filecards/components/cardsgallery/cardsgallery.js
+++ b/client/features/filecards/components/cardsgallery/cardsgallery.js
@@ -59,7 +59,10 @@ function CardsGalleryComponent ({
                     loading={loading && card?.download_url === selectedUrl}
                     pictureImage={card.picture_url}
                     cardSubTitle={cardSubTitle(card.website_url, card.subtitle)}
-                    isDisabled={loading && card?.download_url !== selectedUrl}
+                    isDisabled={(loading)
+                      ? (card?.download_url !== selectedUrl)
+                      : !card.download_url.includes('http')
+                    }
                     downloadFile={() => setSelected(card?.download_url)}
                   />
                 ))}

--- a/client/features/filecards/components/cardsgallery/index.js
+++ b/client/features/filecards/components/cardsgallery/index.js
@@ -48,7 +48,7 @@ function CardsGallery () {
   const cardSubTitle = useCallback((website_url, cardSubtitle) => {
     let subtitle = <span>{cardSubtitle ?? ''}</span>
 
-    if (website_url !== '') {
+    if (website_url.includes('http')) {
       subtitle = <Link href={website_url} target="_blank">
         {cardSubtitle}
       </Link>

--- a/client/features/filecards/components/embedcard/index.js
+++ b/client/features/filecards/components/embedcard/index.js
@@ -69,7 +69,7 @@ function EmbedCardComponent () {
     if (card !== null) {
       subtitle = <span>{card?.subtitle ?? ''}</span>
 
-      if (card?.website_url !== '') {
+      if (card?.website_url.includes('http')) {
         subtitle = <Link href={card.website_url} target="_blank">
           {subtitle}
         </Link>
@@ -78,6 +78,16 @@ function EmbedCardComponent () {
 
     return subtitle
   }, [card])
+
+  const isDisabled = useMemo(() => {
+    if (loading) {
+      return true
+    } else {
+      return (card)
+        ? (card?.download_url === '' || !card?.download_url.includes('http'))
+        : true
+    }
+  }, [loading, card])
 
   return (
     <FullBox sx={styles.container}>
@@ -120,7 +130,7 @@ function EmbedCardComponent () {
                variant="outlined"
                disableElevation
                onClick={downloadFile}
-               disabled={loading}
+               disabled={isDisabled}
                sx={styles.button}
              >
                {(loading)
@@ -134,7 +144,7 @@ function EmbedCardComponent () {
                variant="outlined"
                disableElevation
                onClick={previewFile}
-               disabled={loading}
+               disabled={isDisabled}
                sx={styles.button}
              >
                 View


### PR DESCRIPTION
- Disable card buttons if `card.download_url` is blank or does not contain the string `"http"`