### PR TITLE
Feature/weaponsforge 103

### DIFF
--- a/client/features/authentication/components/withcmsauth/index.js
+++ b/client/features/authentication/components/withcmsauth/index.js
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { useDispatch } from 'react-redux'
 
 import { useAuth } from '@/features/authentication'
-import useInitStore from '@/hooks/useinitstore'
+import { loadedReceived } from '@/store/app/appSlice'
 
 import LoadingCover from '@/components/common/layout/loadingcover'
 import { AdminDrawer } from '@/features/cms'
@@ -19,10 +20,12 @@ import { AdminDrawer } from '@/features/cms'
 function WithCMSAuth (Component) {
   function AuthListener (props) {
     const router = useRouter()
+    const dispatch = useDispatch()
     const { authLoading, authError, authUser } = useAuth()
 
-    // Fetch Posts
-    useInitStore(authUser?.uid ?? undefined)
+    useEffect(() => {
+      dispatch(loadedReceived(true))
+    }, [dispatch])
 
     useEffect(() => {
       if (!authLoading && !authUser) {

--- a/client/features/filecards/containers/list/index.js
+++ b/client/features/filecards/containers/list/index.js
@@ -4,7 +4,10 @@ import { useRouter } from 'next/router'
 
 import { useAuth } from '@/features/authentication'
 import useDeleteCard from '../../hooks/usedeletecard'
+import useInitStore from '@/hooks/useinitstore'
 import { cardsReset } from '@/store/cards/cardSlice'
+import { _getCards } from '@/store/cards/cardThunks'
+
 
 import Button from '@mui/material/Button'
 import ButtonGroup from '@mui/material/ButtonGroup'
@@ -28,6 +31,14 @@ function FileCardsList () {
     // Delete the selected Card from cache
     dispatch(cardsReset())
   }, [dispatch])
+
+  // Fetch all Cards store items just once
+  useInitStore({
+    uid: authUser?.uid ?? undefined,
+    storeName: 'cards',
+    fetchThunk: _getCards,
+    collectionPath: `users/${authUser?.uid}/cards`
+  })
 
   const navigateToPostActionPage = (action, docId) => {
     router.push(`/cms/filecards/${action}?id=${docId}`)

--- a/client/features/posts/components/list/index.js
+++ b/client/features/posts/components/list/index.js
@@ -25,7 +25,7 @@ function CustomToolbar(props) {
 }
 
 function PostsComponent ({ handleDeleteCancel, handleDeleteConfirm, deleteState, deleteSuccess, columns }) {
-  const {ids, entities: posts} = useSelector(state => state.posts)
+  const { ids, entities: posts } = useSelector(state => state.posts)
   const status = useSelector(state => state.posts.status)
 
   return (

--- a/client/features/posts/containers/list/index.js
+++ b/client/features/posts/containers/list/index.js
@@ -4,7 +4,9 @@ import { useRouter } from 'next/router'
 
 import { useAuth } from '@/features/authentication'
 import useDeletePost from '../../hooks/usedeletepost'
+import useInitStore from '@/hooks/useinitstore'
 import { postsReset } from '@/store/posts/postSlice'
+import { _getPosts } from '@/store/posts/postThunks'
 
 import Button from '@mui/material/Button'
 import ButtonGroup from '@mui/material/ButtonGroup'
@@ -28,6 +30,14 @@ function PostsList () {
     // Delete the selected Post from cache
     dispatch(postsReset())
   }, [dispatch])
+
+  // Fetch all Posts store items just once
+  useInitStore({
+    uid: authUser?.uid ?? undefined,
+    storeName: 'posts',
+    fetchThunk: _getPosts,
+    collectionPath: `users/${authUser?.uid}/posts_ref`
+  })
 
   const navigateToPostActionPage = (action, docId) => {
     router.push(`/cms/posts/${action}?id=${docId}`)

--- a/client/src/lib/hooks/useinitstore.js
+++ b/client/src/lib/hooks/useinitstore.js
@@ -1,31 +1,31 @@
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { _getPosts } from '@/store/posts/postThunks'
-import { _getCards } from '@/store/cards/cardThunks'
-import { loadedReceived } from '@/store/app/appSlice'
 
 /**
- * Fetch all user's (reference) Posts and File Cards only once during the initial app load (of any <WithCMSAuth> wrapped components).
- * The reference Posts documents contain the original Posts data minus the Post.content field.
- * @param {String} uid - Signed-in Firebase user's auth ID
- * @returns {Bool} - Client app's initial load state
+ * Fetch a store object's items (entities) only once during initial page load.
+ * @typedef {Object} params - Input parameters.
+ * @param {String} params.uid - Signed-in Firebase user's auth ID
+ * @param {String} params.storeName - Redux slice store selector name
+ * @param {Function} params.fetchThunk - Redux thunk (created with createAsyncThunk) for fetching data
+ * @param {String} params.collectionPath - Firestore slash-separated path to a collection
+ * @returns {Bool} - Selected store's "initialized" (entities loaded) state
  */
-export default function useInitStore (uid) {
-  const loaded = useSelector(state => state.app.loaded)
+export default function useInitStore ({
+  uid,
+  storeName,
+  fetchThunk,
+  collectionPath
+}) {
+  const initialized = useSelector(state => state[storeName].initialized)
   const dispatch = useDispatch()
 
   useEffect(() => {
-    if (!loaded && uid !== undefined) {
-      // Fetch all Posts (references)
-      dispatch(_getPosts(`users/${uid}/posts_ref`))
-
-      // Fetch all Cards
-      dispatch(_getCards(`users/${uid}/cards`))
-      dispatch(loadedReceived(true))
+    if (!initialized && uid !== undefined) {
+      dispatch(fetchThunk(collectionPath))
     }
-  }, [dispatch, uid, loaded])
+  }, [dispatch, uid, initialized, collectionPath, fetchThunk])
 
   return {
-    loaded
+    initialized
   }
 }

--- a/client/src/lib/hooks/useinitstore.js
+++ b/client/src/lib/hooks/useinitstore.js
@@ -16,7 +16,7 @@ export default function useInitStore ({
   fetchThunk,
   collectionPath
 }) {
-  const initialized = useSelector(state => state[storeName].initialized)
+  const initialized = useSelector(state => state[storeName]?.initialized)
   const dispatch = useDispatch()
 
   useEffect(() => {

--- a/client/src/lib/services/posts/index.js
+++ b/client/src/lib/services/posts/index.js
@@ -53,7 +53,8 @@ const getPost = async (documentPath) => {
 }
 
 /**
- * Fetch all Posts documents under a /users/{uid}/posts subcollection
+ * Fetch all Posts reference documents under a /users/{uid}/posts_ref subcollection
+ * The reference Posts (posts_ref) documents contain the original Posts data minus the Post.content field.
  * @param {String} collectionPath - Firestore slash-separated path to a collection
  * @returns
  */

--- a/client/src/lib/store/cards/cardSlice.js
+++ b/client/src/lib/store/cards/cardSlice.js
@@ -25,6 +25,7 @@ const cardSlice = createSlice({
   initialState: cardsAdapter.getInitialState({
     status: ADAPTER_STATES.IDLE,
     currentRequestId: null,
+    initialized: false,
     error: '',
     picturefilename: '',
     attachmentfilename: '',
@@ -74,6 +75,7 @@ const cardSlice = createSlice({
     builder.addCase(_getCards.fulfilled, (state, { payload }) => {
       state.status = ADAPTER_STATES.IDLE
       state.currentRequestId = undefined
+      state.initialized = true
       cardsAdapter.setAll(state, payload)
     })
 

--- a/client/src/lib/store/cards_gallery/cardGallerySlice.js
+++ b/client/src/lib/store/cards_gallery/cardGallerySlice.js
@@ -22,6 +22,7 @@ const cardGallerySlice = createSlice({
   initialState: cardsAdapter.getInitialState({
     status: ADAPTER_STATES.IDLE,
     currentRequestId: null,
+    initialized: false,
     error: '',
     card: null
   }),
@@ -56,6 +57,7 @@ const cardGallerySlice = createSlice({
     builder.addCase(_getCardsByCategory.fulfilled, (state, action) => {
       state.status = ADAPTER_STATES.IDLE
       state.currentRequestId = undefined
+      state.initialized = true
 
       // TO-DO: Investigate why action.payload is sometimes undefined on localhost dev
       // (when navigating using next/router)

--- a/client/src/lib/store/posts/postSlice.js
+++ b/client/src/lib/store/posts/postSlice.js
@@ -26,6 +26,7 @@ const postSlice = createSlice({
   initialState: postsAdapter.getInitialState({
     status: ADAPTER_STATES.IDLE,
     currentRequestId: null,
+    initialized: false,
     error: '',
     post: null
   }),
@@ -54,6 +55,7 @@ const postSlice = createSlice({
     builder.addCase(_getPosts.fulfilled, (state, { payload }) => {
       state.status = ADAPTER_STATES.IDLE
       state.currentRequestId = undefined
+      state.initialized = true
       postsAdapter.setAll(state, payload)
     })
 

--- a/client/src/lib/store/posts/postThunks.js
+++ b/client/src/lib/store/posts/postThunks.js
@@ -37,6 +37,7 @@ export const _createPost = createAsyncThunk('posts/create', async (post, thunkAP
 
 /**
  * Fetch all Posts thunk
+ * The reference Posts (posts_ref) documents contain the original Posts data minus the Post.content field.
  * @params {String} documentPath - Firestore slash-separated path to a Collection
  */
 export const _getPosts = createAsyncThunk('posts/list', async (collectionPath, thunkAPI) => {


### PR DESCRIPTION
- Load main store entities on dedicated page routes just once during initial page load, [#103](https://github.com/weaponsforge/climate-profile-full/issues/103)